### PR TITLE
Make Unitz work on node

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.1",
   "description": "A unit parser, converter, & combiner in JS",
   "author": "Philip Diffenderfer",
+  "main": "src/Unitz.js",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.1",
   "description": "A unit parser, converter, & combiner in JS",
   "author": "Philip Diffenderfer",
-  "main": "src/Unitz.js",
+  "main": "build/unitz.js",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Node requires a `main` in the package.json when you use a custom entry point.
